### PR TITLE
Fixed loading of old harmony for shimmed plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Why the fork?
-[ScriptLoader has a minor bug that would...](https://github.com/ghorsington/BepInEx.ScriptLoader/issues/4) fixed in this fork.
+[ScriptLoader has a minor bug that would ](https://github.com/ghorsington/BepInEx.ScriptLoader/issues/4) fixed in this fork.
 
 # ScriptLoader for BepInEx 5.4
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# Why the fork?
-[ScriptLoader has a minor bug that would ](https://github.com/ghorsington/BepInEx.ScriptLoader/issues/4) fixed in this fork.
-
 # ScriptLoader for BepInEx 5.4
 
 This is a BepInEx 5 plugin that allows you to run C# script files without compiling them to a DLL.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Why the fork?
+[ScriptLoader has a minor bug that would ](https://github.com/ghorsington/BepInEx.ScriptLoader/issues/4) fixed in this fork.
+
 # ScriptLoader for BepInEx 5.4
 
 This is a BepInEx 5 plugin that allows you to run C# script files without compiling them to a DLL.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Why the fork?
-[ScriptLoader has a minor bug that would ](https://github.com/ghorsington/BepInEx.ScriptLoader/issues/4) fixed in this fork.
+[ScriptLoader has a minor bug that would...](https://github.com/ghorsington/BepInEx.ScriptLoader/issues/4) fixed in this fork.
 
 # ScriptLoader for BepInEx 5.4
 

--- a/ScriptLoader/MonoCompiler.cs
+++ b/ScriptLoader/MonoCompiler.cs
@@ -128,7 +128,10 @@ namespace ScriptLoader
             {
                 if (StdLib.Contains(ass.name.Name) || compiledAssemblies.Contains(ass.name.Name))
                     continue;
-                import(ass.ass);
+                //Prevents ScriptLoader from using the old harmony library that is used for shimmed plugins.
+                if (ass.name.Name.Equals("0Harmony20"))
+	                continue;
+				import(ass.ass);
             }
         }
 


### PR DESCRIPTION
#4 If a plugin was shimmed by bepinex before the scriptloader was loaded, it would cause the scriptloader to load 0Harmony20, allowing the usage of old patch functions such as UnpatchAll which are now obsolete.